### PR TITLE
Update sketch.js

### DIFF
--- a/demos/teachableMachine/sketch.js
+++ b/demos/teachableMachine/sketch.js
@@ -65,7 +65,11 @@ function setup() {
 
 function draw() {
   background(0);
-  image(video, 0, 0, width, height);
+  push(); // flip video direction so it works like a mirror
+    translate(width, 0);
+    scale(-1, 1);
+    image(video, 0, 0, width, height);
+  pop();  
 }
 
 // A function to be called when the model has been loaded


### PR DESCRIPTION
Hi, I've noticed that the capture video object in the Teachable Machine demo is not flipped, and I felt it makes it a little bit confusing to use. This commit changes the drawing direction so the captured video stream acts like a mirror.